### PR TITLE
Adds bicycle shortcut

### DIFF
--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -690,6 +690,9 @@ ItemUseBicycle:
 	xor a
 	ld [wWalkBikeSurfState],a ; change player state to walking
 	call PlayDefaultMusic ; play walking music
+	ld a,[wPseudoItemID]
+	and a ; if using select shortcut
+	ret nz
 	ld hl,GotOffBicycleText
 	jr .printText
 .tryToGetOnBike
@@ -700,8 +703,11 @@ ItemUseBicycle:
 	ld [hJoyHeld],a ; current joypad state
 	inc a
 	ld [wWalkBikeSurfState],a ; change player state to bicycling
-	ld hl,GotOnBicycleText
 	call PlayDefaultMusic ; play bike riding music
+	ld a,[wPseudoItemID]
+	and a ; if using select shortcut
+	ret nz
+	ld hl,GotOnBicycleText
 .printText
 	jp PrintText
 

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -685,8 +685,17 @@ ItemUseBicycle:
 	jp z,ItemUseNotTime
 	dec a ; is player already bicycling?
 	jr nz,.tryToGetOnBike
-.getOffBike
+.tryToGetOffBike
 	call ItemUseReloadOverworldData
+	ld a,[wPseudoItemID]
+	and a ; if not using select shortcut
+	jr z,.getOffBike
+	; check cycling road
+	ld a,[wd732]
+	bit 5,a
+	jr z,.getOffBike ; if not on cycling road, get off bike
+	jr .printCannotGetOffText
+.getOffBike
 	xor a
 	ld [wWalkBikeSurfState],a ; change player state to walking
 	call PlayDefaultMusic ; play walking music
@@ -710,6 +719,13 @@ ItemUseBicycle:
 	ld hl,GotOnBicycleText
 .printText
 	jp PrintText
+.printCannotGetOffText
+	ld hl,CannotGetOffBicycleText
+	jp PrintText
+
+CannotGetOffBicycleText:
+	TX_FAR _CannotGetOffHereText
+	db "@"
 
 ; used for Surf out-of-battle effect
 ItemUseSurfboard:

--- a/engine/overworld/bike_shortcut.asm
+++ b/engine/overworld/bike_shortcut.asm
@@ -17,7 +17,17 @@ TryRideBike::
      jr .cleanUp
 .hasBike
      farcall IsBikeRidingAllowed
-     jr c,.useItem
+     jr c,.checkSurfing
+     call EnableBikeShortcutText
+.checkSurfing
+     ld a,[wWalkBikeSurfState]
+     cp a,2
+     jr nz,.checkCyclingRoad ; if not surfing
+     call EnableBikeShortcutText
+.checkCyclingRoad
+     ld a,[wd732] ; cycling road
+     bit 5,a
+     jr z,.useItem ;if not on cycling road skip text
      call EnableBikeShortcutText
 .useItem
      call UseItem

--- a/engine/overworld/bike_shortcut.asm
+++ b/engine/overworld/bike_shortcut.asm
@@ -7,15 +7,19 @@ TryRideBike::
      ld [wd11e],a ; store item ID for GetItemName
      call GetItemName
      call CopyStringToCF4B ; copy name to wcf4b
-     call EnableBikeShortcutText
 .tryForBike
      ld b,BICYCLE
      call IsItemInBag
      jr nz,.hasBike
+     call EnableBikeShortcutText
      ld hl,TextNoBike ; if no bike
      call PrintText
      jr .cleanUp
 .hasBike
+     farcall IsBikeRidingAllowed
+     jr c,.useItem
+     call EnableBikeShortcutText
+.useItem
      call UseItem
 .cleanUp
      call CloseBikeShortcutText

--- a/engine/overworld/bike_shortcut.asm
+++ b/engine/overworld/bike_shortcut.asm
@@ -1,0 +1,40 @@
+TryRideBike::
+     xor a
+.setUp
+     ld a,BICYCLE
+     ld [wcf91],a
+     ld [wPseudoItemID],a
+     ld [wd11e],a ; store item ID for GetItemName
+     call GetItemName
+     call CopyStringToCF4B ; copy name to wcf4b
+     call EnableBikeShortcutText
+.tryForBike
+     ld b,BICYCLE
+     call IsItemInBag
+     jr nz,.hasBike
+     ld hl,TextNoBike ; if no bike
+     call PrintText
+     jr .cleanUp
+.hasBike
+     call UseItem
+.cleanUp
+     call CloseBikeShortcutText
+     ret
+
+TextNoBike:
+     TX_FAR _NoBicycleText1
+     TX_LINE
+     TX_FAR _NoBicycleText2
+     db "@"
+
+EnableBikeShortcutText: ; Gets everything setup to let you display text properly
+	call EnableAutoTextBoxDrawing
+	ld a, 1 ; not 0
+	ld [hSpriteIndexOrTextID], a
+	farcall DisplayTextIDInit
+	ret
+
+CloseBikeShortcutText: ; Closes the text out properly to prevent glitches
+	ld a,[H_LOADEDROMBANK]
+	push af
+	jp CloseTextDisplay

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -68,10 +68,15 @@ OverworldLoopLessDelay::
 	bit 7,a ; are we simulating button presses?
 	jr z,.notSimulating
 	ld a,[hJoyHeld]
-	jr .checkIfStartIsPressed
+	jr .checkIfSelectIsPressed
 .notSimulating
 	ld a,[hJoyPressed]
-.checkIfStartIsPressed
+.checkIfSelectIsPressed
+	bit 2,a ; select button
+	jr z,.selectButtonNotPressed
+; if SELECT is pressed
+	farcall TryRideBike
+.selectButtonNotPressed
 	bit 3,a ; start button
 	jr z,.startButtonNotPressed
 ; if START is pressed
@@ -95,11 +100,11 @@ OverworldLoopLessDelay::
 	ld a,[hSpriteIndexOrTextID]
 	and a
 	jr nz, .displayDialogue
-	
+
 	; Check for field moves that interact with the bg.
 	predef TryFieldMove
 	jp OverworldLoop
-	
+
 .displayDialogue
 	predef GetTileAndCoordsInFrontOfPlayer
 	call UpdateSprites
@@ -1290,11 +1295,11 @@ CollisionCheckOnLand::
 	;ld a,[wChannelSoundIDs + Ch4]
 	;cp SFX_COLLISION ; check if collision sound is already playing
 	; curSFX is not cleared for some reason.
-	
+
     ; ch5 on?
     ld hl, Channel5 + Channel1Flags - Channel1
     bit 0, [hl]
-    
+
 	jr nz,.setCarry
 	ld a,SFX_COLLISION
 	call PlaySound ; play collision sound (if it's not already playing)

--- a/main.asm
+++ b/main.asm
@@ -2654,6 +2654,7 @@ INCLUDE "engine/splashscreens/version_screen.asm"
 INCLUDE "engine/splashscreens/players_in_intro.asm"
 INCLUDE "engine/overworld/headbutt.asm"
 INCLUDE "engine/sliding_tile_puzzle.asm"
+INCLUDE "engine/overworld/bike_shortcut.asm"
 
 SECTION "Trainer Parties", ROMX,BANK[$3B]
 INCLUDE "engine/battle/read_trainer_party.asm"

--- a/text.asm
+++ b/text.asm
@@ -2963,6 +2963,15 @@ _GotOffBicycleText2::
 	text "."
 	prompt
 
+_NoBicycleText1::
+	text "[PLAYER] hasn't got@@"
+
+_NoBicycleText2::
+	text "a @"
+	TX_RAM wcf4b
+	text "."
+	prompt
+
 _ThrewAwayItemText::
 	text "Threw away"
 	line "@"


### PR DESCRIPTION
Lets you use the bike (if you have one) by pressing `SELECT` on the overworld -- it checks whether you have the bike and all the normal stuff that checks whether you're _allowed_ to get on the bike should still work.