### PR TITLE
Fixed compilation error on MacOsx

### DIFF
--- a/home.asm
+++ b/home.asm
@@ -4342,13 +4342,15 @@ print_digit: macro
 
 if (\1) / $10000
 	ld a, \1 / $10000 % $100
-else	xor a
+else
+	xor a
 endc
 	ld [H_POWEROFTEN + 0], a
 
 if (\1) / $100
 	ld a, \1 / $100   % $100
-else	xor a
+else
+	xor a
 endc
 	ld [H_POWEROFTEN + 1], a
 


### PR DESCRIPTION
This tiny commit fixed compilation on MacOsX Catalina 10.15.7 using rgbds 0.4.2.
It doesn't fix compilation errors I'm still getting on Centos 7 despite following the installation guide